### PR TITLE
Change the description and screenshot (#66)

### DIFF
--- a/packages.plist
+++ b/packages.plist
@@ -694,10 +694,10 @@
 			},
 			{
 				name = "ChangeIncrement.glyphsPalette";
-				title = "Change Keyboard Increment";
+				title = "Keyboard Increment";
 				url = "https://github.com/filipenegrao/Change-Keyboard-Increment";
-				description = "It changes the default keyboard increment value to a settable new one.";
-				screenshot = "https://raw.githubusercontent.com/filipenegrao/Change-Keyboard-Increment/master/change_increment.png";
+				description = "This is the new version of the Keyboard Increment Plug-in that allows you to change the default value for whatever value you want.";
+				screenshot = "https://github.com/filipenegrao/Keyboard-Increment/blob/a2f95c60e47f6ab493bf1401433ecb57125882b5/keyboard-increment-plugin-darkmode.png";
 			},
 			{
 				name = "MakeBoxes.glyphsFilter";


### PR DESCRIPTION
* Keyboard Plug-in Major Update

This is a total remodeling for the Keyboard Increment Palette Plug-in. Now, it has two versions, one for Mac OS Catalina and Big Sur and other for Mojave, High Sierra and Sierra.

* update plist

Removed un-needed plug-in

* Back to the old repo location and Plug-in name

I'm also updating the description and the screenshot

Co-authored-by: filipenegrao <hello@filipenegrao.com>